### PR TITLE
Better handling  toJSON + tests for toJSON

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,11 +120,13 @@ export default function devalue(value: any, level = defaultLogLevel) {
 				return `new ${type}([${Array.from(thing).map(stringify).join(',')}])`;
 
 			default:
-				const thingToSerialize = thing.toJSON ? thing.toJSON() : thing;
-				const obj = `{${Object.keys(thingToSerialize).map(key => `${safeKey(key)}:${stringify(thingToSerialize[key])}`).join(',')}}`;
-				const proto = Object.getPrototypeOf(thingToSerialize);
+				if (thing.toJSON) {
+					return stringify(JSON.parse(thing.toJSON()));
+				}
+				const obj = `{${Object.keys(thing).map(key => `${safeKey(key)}:${stringify(thing[key])}`).join(',')}}`;
+				const proto = Object.getPrototypeOf(thing);
 				if (proto === null) {
-					return Object.keys(thingToSerialize).length > 0
+					return Object.keys(thing).length > 0
 						? `Object.assign(Object.create(null),${obj})`
 						: `Object.create(null)`;
 				}

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,6 @@ export default function devalue(value: any, level = defaultLogLevel) {
 	walk(value);
 
 	const names = new Map();
-
 	Array.from(counts)
 		.filter(entry => entry[1] > 1)
 		.sort((a, b) => b[1] - a[1])
@@ -121,7 +120,15 @@ export default function devalue(value: any, level = defaultLogLevel) {
 
 			default:
 				if (thing.toJSON) {
-					return stringify(JSON.parse(thing.toJSON()));
+					let json = thing.toJSON();
+					if (getType(json) === 'String') {
+						//try to parse
+						//because we can't see the different json string or plain string 
+						try {
+							json = JSON.parse(json)
+						} catch (e) {};
+					}
+					return stringify(json);
 				}
 				const obj = `{${Object.keys(thing).map(key => `${safeKey(key)}:${stringify(thing[key])}`).join(',')}}`;
 				const proto = Object.getPrototypeOf(thing);

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,8 +122,7 @@ export default function devalue(value: any, level = defaultLogLevel) {
 				if (thing.toJSON) {
 					let json = thing.toJSON();
 					if (getType(json) === 'String') {
-						//try to parse
-						//because we can't see the different json string or plain string 
+						// Try to parse the returned data
 						try {
 							json = JSON.parse(json)
 						} catch (e) {};
@@ -134,7 +133,7 @@ export default function devalue(value: any, level = defaultLogLevel) {
 				const proto = Object.getPrototypeOf(thing);
 				if (proto === null) {
 					return Object.keys(thing).length > 0
-						? `Object.assign(Object.create(null),${obj})`
+						? `Object.assign(Object.create(null), ${obj})`
 						: `Object.create(null)`;
 				}
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -2,9 +2,6 @@ import * as assert from 'assert';
 import * as vm from 'vm';
 import devalue from '../src/index';
 
-
-
-
 describe('devalue', () => {
 	function test(name: string, input: any, expected: string) {
 		it(name, () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -44,13 +44,20 @@ describe('devalue', () => {
 		test('Object', {foo: 'bar', 'x-y': 'z'}, '{foo:"bar","x-y":"z"}');
 		test('Set', new Set([1, 2, 3]), 'new Set([1,2,3])');
 		test('Map', new Map([['a', 'b']]), 'new Map([["a","b"]])');
-		test('toJSON Array', new toJSONTest('["a", "b", "c"]'), '["a","b","c"]');
-		test('toJSON Array (empty)', new toJSONTest('[]'), '[]');
-		test('toJSON Object', new toJSONTest('{"foo":"bar","x-y":"z"}'), '{foo:"bar","x-y":"z"}');
-		test('toJSON Object (deep)', new toJSONTest('{"foo":"bar","x-y": [1,2,{"a":"b"}]}'), '{foo:"bar","x-y":[1,2,{a:"b"}]}');
-		test('toJSON Boolean', new toJSONTest('true'), 'true');
-		test('toJSON Number', new toJSONTest('1'), '1');
-		test('toJSON String', new toJSONTest('"test"'), '"test"');
+		test('toJSON (string) Array', new toJSONTest('["a", "b", "c"]'), '["a","b","c"]');
+		test('toJSON (string) Array (empty)', new toJSONTest('[]'), '[]');
+		test('toJSON (string) Object', new toJSONTest('{"foo":"bar","x-y":"z"}'), '{foo:"bar","x-y":"z"}');
+		test('toJSON (string) (deep)', new toJSONTest('{"foo":"bar","x-y": [1,2,{"a":"b"}]}'), '{foo:"bar","x-y":[1,2,{a:"b"}]}');
+		test('toJSON (string) Boolean', new toJSONTest('true'), 'true');
+		test('toJSON (string) Number', new toJSONTest('1'), '1');
+		test('toJSON (string) String', new toJSONTest('"test"'), '"test"');
+		test('toJSON Array', new toJSONTest(["a", "b", "c"]), '["a","b","c"]');
+		test('toJSON Array (empty)', new toJSONTest([]), '[]');
+		test('toJSON Object', new toJSONTest({"foo":"bar","x-y":"z"}), '{foo:"bar","x-y":"z"}');
+		test('toJSON Object (deep)', new toJSONTest({"foo":"bar","x-y": [1,2,{"a":"b"}]}), '{foo:"bar","x-y":[1,2,{a:"b"}]}');
+		test('toJSON Boolean', new toJSONTest(true), 'true');
+		test('toJSON Number', new toJSONTest(1), '1');
+		test('toJSON String', new toJSONTest("test"), '"test"');
 	});
 
 	describe('cycles', () => {

--- a/test/test.ts
+++ b/test/test.ts
@@ -2,6 +2,9 @@ import * as assert from 'assert';
 import * as vm from 'vm';
 import devalue from '../src/index';
 
+
+
+
 describe('devalue', () => {
 	function test(name: string, input: any, expected: string) {
 		it(name, () => {
@@ -9,6 +12,17 @@ describe('devalue', () => {
 			assert.equal(actual, expected);
 		});
 	}
+
+	class toJSONTest {
+		private toJSONValue: any
+		constructor (toJSONValue: any) {
+			this.toJSONValue = toJSONValue;
+		}
+		toJSON () {
+			return this.toJSONValue;
+		}
+	}
+
 
 	describe('basics', () => {
 		test('number', 42, '42');
@@ -33,6 +47,13 @@ describe('devalue', () => {
 		test('Object', {foo: 'bar', 'x-y': 'z'}, '{foo:"bar","x-y":"z"}');
 		test('Set', new Set([1, 2, 3]), 'new Set([1,2,3])');
 		test('Map', new Map([['a', 'b']]), 'new Map([["a","b"]])');
+		test('toJSON Array', new toJSONTest('["a", "b", "c"]'), '["a","b","c"]');
+		test('toJSON Array (empty)', new toJSONTest('[]'), '[]');
+		test('toJSON Object', new toJSONTest('{"foo":"bar","x-y":"z"}'), '{foo:"bar","x-y":"z"}');
+		test('toJSON Object (deep)', new toJSONTest('{"foo":"bar","x-y": [1,2,{"a":"b"}]}'), '{foo:"bar","x-y":[1,2,{a:"b"}]}');
+		test('toJSON Boolean', new toJSONTest('true'), 'true');
+		test('toJSON Number', new toJSONTest('1'), '1');
+		test('toJSON String', new toJSONTest('"test"'), '"test"');
 	});
 
 	describe('cycles', () => {
@@ -75,6 +96,12 @@ describe('devalue', () => {
 			`</script><script src='https://evil.com/script.js'>alert('pwned')</script><script>`,
 			`"\\u003C\\u002Fscript\\u003E\\u003Cscript src='https:\\u002F\\u002Fevil.com\\u002Fscript.js'\\u003Ealert('pwned')\\u003C\\u002Fscript\\u003E\\u003Cscript\\u003E"`
 		);
+		test(
+			'toJSON Dangerous string',
+			new toJSONTest(`"</script><script src='https://evil.com/script.js'>alert('pwned')</script><script>"`),
+			`"\\u003C\\u002Fscript\\u003E\\u003Cscript src='https:\\u002F\\u002Fevil.com\\u002Fscript.js'\\u003Ealert('pwned')\\u003C\\u002Fscript\\u003E\\u003Cscript\\u003E"`
+		);
+
 	});
 
 	describe('misc', () => {


### PR DESCRIPTION
`toJSON` was not correctly handled, `toJSON`  returns always `string` what then was again parsed, but the string doesn't always have object, it can also be array, string, number etc. So it was always returning a object. for example `[0,1,2]` became `{0:1,1:1, 2:2}` this fix the wrongly handling of toJSON, plus I've added unit test for this.
