### PR TITLE
try to use "toJSON" method before converting named objects to string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/devalue",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Gets the job done when JSON.stringify can't",
   "repository": "nuxt-community/devalue",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuxt/devalue",
-  "version": "1.2.5",
+  "version": "1.2.4",
   "description": "Gets the job done when JSON.stringify can't",
   "repository": "nuxt-community/devalue",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -204,6 +204,19 @@ export default function devalue(value: any, level = defaultLogLevel) {
 					break;
 
 				default:
+					if (thing && thing.toJSON) {
+						let json = thing.toJSON();
+						if (getType(json) === 'String') {
+							// Try to parse the returned data
+							try {
+								json = JSON.parse(json);
+							} catch (e) {
+								json = thing;
+							};
+						}
+						thing = json;
+					}
+
 					values.push(Object.getPrototypeOf(thing) === null ? 'Object.create(null)' : '{}');
 					Object.keys(thing).forEach(key => {
 						statements.push(`${name}${safeProp(key)}=${stringify(thing[key])}`);


### PR DESCRIPTION
Nuxt uses devalue to pass vuex state from server- to client-side. And at the moment devalue converts simple objects to "json format" as is, key by key. But sometimes it is usefull to make some changes in a data before this conversion, "toJSON" method should be used for this.

For example, I create data models with default empty values on server-side, but due to some logic of my app the models were left as is, with default values, so there is no need to pass all keys of empty models to client-side, because I can create new empty models on client-side. So in this case the data model should have "toJSON" method, and devalue should call it. The method may look like this:

```
toJSON ()
{
	return is_new(this) ? {} : this;
}
```