### PR TITLE
fix: devalue will return private data to the client even if toJSON is implemented.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export default function devalue(value: any, level = defaultLogLevel) {
 	}
 
 
-	function walk(thing: any) {
+	function walk(thing: any, parent:any, key:string, index:number) {
 		if (typeof thing === 'function') {
 			consola[level](`Cannot stringify a function ${thing.name}`)
 			return
@@ -60,15 +60,33 @@ export default function devalue(value: any, level = defaultLogLevel) {
 					return;
 
 				case 'Array':
-					thing.forEach(walk);
+					thing.forEach((item:any, index:number)=>{walk(item, parent, key, index)});
 					break;
 
 				case 'Set':
 				case 'Map':
-					Array.from(thing).forEach(walk);
+					Array.from(thing).forEach((item, index)=>{walk(item, parent,key, undefined)});
 					break;
 
 				default:
+					if (thing && thing.toJSON) {
+						let json = thing.toJSON();
+						if (getType(json) === 'String') {
+							// Try to parse the returned data
+							try {
+								json = JSON.parse(json);
+							} catch (e) {
+								json = thing;
+							};
+						}
+
+						if(typeof index !== 'undefined')
+							parent[key][index] = json;
+						else
+							parent[key] = json;
+						return;
+					}
+
 					const proto = Object.getPrototypeOf(thing);
 
 					if (
@@ -82,14 +100,14 @@ export default function devalue(value: any, level = defaultLogLevel) {
 					} else if (Object.getOwnPropertySymbols(thing).length > 0) {
 						log(`Cannot stringify POJOs with symbolic keys ${Object.getOwnPropertySymbols(thing).map(symbol => symbol.toString())}`);
 					} else {
-						Object.keys(thing).forEach(key => walk(thing[key]));
+						Object.keys(thing).forEach(function (key) { return walk(thing[key], thing, key, undefined); });
 					}
 
 			}
 		}
 	}
 
-	walk(value);
+	walk(value, undefined, undefined, undefined);
 
 	const names = new Map();
 	Array.from(counts)


### PR DESCRIPTION
nuxt-contrib/devalue does not handle toJSON properly.  There was a fix made earlier and there is an open pull request for another fix.  However, that pull request is not correct either. 

Here is an example that demonstrates the problems. There are 2 problems:

- The current implementation would not run toJSON always and instead return the object with all its hidden properties.
- If the same object is referenced twice, only the first one is properly handled. For example, let's say you have an array of 2 products and each product is referencing the same User object instance.  The existing code will call toJSON on the first product1.User but not the product2.User.  Again, it returns the hidden properties.
- The existing code will not handle arrays of objects that also need to be toJSONified.  

Here is example: There is a class **User** that implements toJSON where it excludes certain fields. In this case, it's **"internal"** that should be excluded. In the example below, you will see that "old code output" shows internal returned to the client.  

```
class User
{
    constructor()
    {
        this.valueA = 1;
        this.valueB = 2;
        this.internal = 3;
    }

    toJSON()
    {
        //internal is removed.
        return {valueA: this.valueA, valueB: this.valueB}
    }
}


let user = new User();

let data = {
    data       : user,
    arrayOfData: [user, new User()],
};

console.warn('[TEST1] The output below shows the property "internal" when it was removed in the toJSON.')
console.log('current code output: ', devalue(data));
console.log('new code output    : ', "(function(a){a.valueA=1;a.valueB=2;return {data:a,arrayOfData:[a,{valueA:1,valueB:2}]}}({}))");
console.log('old code output    : ', "(function(a){a.valueA=1;a.valueB=2;a.internal=3;return {data:a,arrayOfData:[a,{valueA:1,valueB:2}]}}({}))");

```
I tried very hard to not touch the existing code to make sure that nothing breaks. So you'll see that I let the existing code add a property to a map and then I remove it. I also introduced additional walk parameters to handle the update of the parent with the JSONified data. I would like to rewrite the code at some point but I have to deal with duplicates which this code doesn't handle perfectly when dealing with JSONified objects.  There is a performance concern with that so I have a hack that I'm happy to discuss with the team once we get past this. 

**I ran the mocha test and all 61 are passing.**

### My motivation
Other than this is a security issue as it may return data that isn't meant for the browser. I'm returning my object data and hydrating it on the client with the proper class instance.  Without toJSON working properly I cannot return the class name that needs to be instantiated.  This fix will solve both the security problem and give programmers a way to hydrate their own data. 

_In my 30 years of programming, this is the first time I make edits to a Typescript file so let me know if I could do things better._ 
