### PR TITLE
fix: throw error if non-POJO is an error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,11 @@ export default function devalue (value: any) {
             Object.getOwnPropertyNames(proto).sort().join('\0') !== objectProtoOwnPropertyNames
           ) {
             if (typeof thing.toJSON !== 'function') {
+              if (thing instanceof error) {
+                const newMessage = `Cannot stringify error ${thing.constructor.name} since it is non-POJOs. Original error:  ${thing.message}`
+                thing.message = newMessage
+                throw thing
+              }
               log(`Cannot stringify arbitrary non-POJOs ${thing.constructor.name}`)
             }
           } else if (Object.getOwnPropertySymbols(thing).length > 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ export default function devalue (value: any) {
             Object.getOwnPropertyNames(proto).sort().join('\0') !== objectProtoOwnPropertyNames
           ) {
             if (typeof thing.toJSON !== 'function') {
-              if (thing instanceof error) {
+              if (thing instanceof Error) {
                 const newMessage = `Cannot stringify error ${thing.constructor.name} since it is non-POJOs. Original error:  ${thing.message}`
                 thing.message = newMessage
                 throw thing


### PR DESCRIPTION
This pull request gives a _better UX_ to a developer using nuxt. Right now, if an error is thrown and that cannot be stringified, the only thing shown is the error name —for example: `TypeError`—. With these changes, if the thing that is being stringified is an error, instead of just showing the name, the error is re-thrown, with an extended error message.